### PR TITLE
hotfix wifi reconnect time

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
     -D DEBUG_ESP_WIFI
-    -D SRC_REV=450
+    -D SRC_REV=457
 lib_deps =
     U8g2
     https://github.com/hpsaturn/HPMA115S0.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -473,7 +473,7 @@ void wifiConnect(const char* ssid, const char* pass) {
   int wifi_retry = 0;
   while (WiFi.status() != WL_CONNECTED && wifi_retry++ < WIFI_RETRY_CONNECTION) {
     Serial.print(".");
-    delay(250);
+    delay(500);           // increment this delay on possible reconnect issues
   }
   if(wifiCheck()){
     cfg.isNewWifi=false;  // flag for config via BLE


### PR DESCRIPTION
when the devices try to reconnect it go to crash, we increment the connection wait delay