### PR TITLE
Av/fix watchdogtime ifxfb issue

### DIFF
--- a/lib/canairioapi/src/CanAirIoApi.hpp
+++ b/lib/canairioapi/src/CanAirIoApi.hpp
@@ -26,7 +26,7 @@ class CanAirIoApi
 
   ~CanAirIoApi();
  
-  void configure(const char nameId[], const char deviceId[], const char target[] = "points/save/", const char host[] = "canairio.herokuapp.com", const uint16_t port = 80);
+  void configure(const char nameId[], const char deviceId[], const char target[] = "points/save/", const char host[] = "api.canair.io", const uint16_t port = 80);
 
   void authorize(const char username[],const char password[]);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
     -D DEBUG_ESP_WIFI
-    -D SRC_REV=490
+    -D SRC_REV=497
 lib_deps =
     U8g2
     https://github.com/hpsaturn/HPMA115S0.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,7 +630,7 @@ void IRAM_ATTR resetModule(){
 void enableWatchdog(){
   timer = timerBegin(0, 80, true);                 // timer 0, div 80
   timerAttachInterrupt(timer, &resetModule, true); // setting callback
-  timerAlarmWrite(timer, 15000000, false);         // set time in us (15s)
+  timerAlarmWrite(timer, 60000000, false);         // set time in us (60s)
   timerAlarmEnable(timer);                         // enable interrupt
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -43,7 +43,7 @@ bool oldDeviceConnected = false;
 CanAirIoApi api(false);
 
 // InfluxDB fields
-#define IFX_RETRY_CONNECTION   5
+#define IFX_RETRY_CONNECTION   2
 InfluxArduino influx;
 
 // Config and settings handler


### PR DESCRIPTION
- InfluxDb write time sync with watchdog time
- set to default api.canair.io on API library