### PR TITLE
removed validation for 0 case, untested yet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -417,9 +417,6 @@ void influxDbAddTags(char* tags) {
 }
 
 bool influxDbWrite() {
-  if(apm25 == 0 || apm10 == 0) {
-    return false;
-  }
   char tags[64];
   influxDbAddTags(tags);
   char fields[256];


### PR DESCRIPTION
## Description

Possible fix to issue #64 on influxdb write function for 0 case issue on average vectors 

## Related Issues

#64 

## Tests

Compiling test: OK
Device test: Untested 
